### PR TITLE
replacing bad char with a space

### DIFF
--- a/bin/puppet-push
+++ b/bin/puppet-push
@@ -124,7 +124,7 @@ function sync_fact() {
 
 	# Move the facts to the central puppet location
 	mv "${PUPPET_PUSH_BASE}/pending/${TARGET}.yaml" "${PUPPET_VAR_DIR}/yaml/facts/${TARGET}.yaml" \
-		|| kickthebucket "Unable to copy facts for node ${TARGET} to puppet directory"
+		|| kickthebucket "Unable to copy facts for node ${TARGET} to puppet directory"
 
 	# Perms are important
 	chown puppet:puppet "${PUPPET_VAR_DIR}/yaml/facts/${TARGET}.yaml"


### PR DESCRIPTION
Invalid non-printing character in place of a space was preventing proper operation. Seems to be the only one.  Hex code c2  a0:

00000dd0  20 5c 0a 09 09 7c 7c c2  a0 6b 69 63 6b 74 68 65  | \...||..kickthe|