### PR TITLE
Pass environment to the puppet apply command 

### DIFF
--- a/bin/puppet-push
+++ b/bin/puppet-push
@@ -214,7 +214,7 @@ function applycatalog() {
 
 	APPLYLOG=$(mktemp '/tmp/puppet-push-apply.XXXXXXXX')
 	trap "rm -f ${APPLYLOG}" EXIT
-	ssh ${REMOTE_SSH_USER}@${TARGET} "puppet apply --catalog ${PUPPET_PUSH_BASE}/catalog ${PUPPET_ARGS}" \
+	ssh ${REMOTE_SSH_USER}@${TARGET} "puppet apply --environment ${PUPPET_ENVIRONMENT} --catalog ${PUPPET_PUSH_BASE}/catalog ${PUPPET_ARGS}" \
 		&> ${APPLYLOG}
 
 	egrep '^\[.;..m(fail|warning|err|crit|alert)' "${APPLYLOG}" > /dev/null


### PR DESCRIPTION
so we do not depend on a preconfigured puppet.conf on the target, thus eliminating a manual step in DMZ host preparation for puppet.  

A catalog can now be compiled for an arbitrary environment as far as the master's puppet tree is concerned (ie: "dmz"), and applied to any remote machine even if it is (by default) set to environment=production, so that vanilla machines can be used without inventing a way to automate puppet.conf editing.

