### PR TITLE
treating multiple module paths separately so all can be synchronized …

### DIFF
--- a/bin/puppet-push
+++ b/bin/puppet-push
@@ -174,15 +174,21 @@ function compile_catalog() {
 # Pushes files from the File[] resource which use "source =>"
 # Only copies relevant files extracted from catalog
 function push_files() {
-	info "Pushing module files"
-	local FILESOURCES=$(extract-file-sources.py ${TARGET})
-	if [ -n "${FILESOURCES}" ]; then
-		rsync -a -R --delete ${FILESOURCES} ${REMOTE_SSH_USER}@${TARGET}:${PUPPET_PUSH_BASE}/modules/ || \
-			kickthebucket "problems rsync'ing files"
-		cd /
-	else
-		info "...No module files"
-	fi
+	local MODULE_ROOT
+	# Treat each possible module directory individually
+	for MODULE_ROOT in ${PUPPET_MODULE_DIR//:/ } ; do
+		info "Pushing module files (${MODULE_ROOT})"
+		local FILESOURCES=$(PUPPET_MODULE_DIR=$MODULE_ROOT extract-file-sources.py ${TARGET})
+		if [ -n "${FILESOURCES}" ]; then
+			cd $MODULE_ROOT
+			MODULE_ROOT="${MODULE_ROOT}/" # strip inluding the trailing slash
+			rsync -a -R --delete ${FILESOURCES#${MODULE_ROOT}} ${REMOTE_SSH_USER}@${TARGET}:${PUPPET_PUSH_BASE}/modules/ || \
+				kickthebucket "problems rsync'ing files"
+			cd /
+		else
+			info "...No module files"
+		fi
+	done
 }
 
 


### PR DESCRIPTION
…to the target filesystem and remain relative.

Current code does not handle the following:

Let's say I'm using environment "X" and have the following files:
> /etc/puppet/environments/X/modules/MODULE_NAME1/files/SOME/FILE.TXT
> /etc/puppet/modules/MODULE_NAME2/files/SOME/OTHERFILE.TXT
(The second one is inherited by all environments)

Manifests will refer to the files as follows, without specifying env's:
> source => "puppet:///modules/MODULE_NAME1/SOME/FILE.TXT"
or
> source => "puppet:///modules/MODULE_NAME2/SOME/OTHERFILE.TXT"

The rsync action should copy paths from both locations, removing "/etc/puppet/environments/X/modules/" and "/etc/puppet/modules/" from the file paths.   Now the rewritten paths will be correct (/var/lib/puppet-push/modules/MODULE_NAME.....)

Currently the code creates /var/lib/puppet-push/etc/puppet/modules..... which is incorrect.
